### PR TITLE
Enable MAX Serve Telemetry Collection

### DIFF
--- a/src/api/max/maxServeService.ts
+++ b/src/api/max/maxServeService.ts
@@ -85,7 +85,9 @@ class MaxServeService {
       all: true,
       env: {
         MAX_SERVE_LOGS_OTLP_LEVEL: "DEBUG",
-        MAX_SERVE_DEPLOYMENT_ID: `INTERNAL_MODULAR_CONSOLE`
+        MAX_SERVE_DEPLOYMENT_ID: `INTERNAL_MODULAR_CONSOLE`,
+        MAX_SERVE_METRIC_LEVEL: "DETAILED",
+        MAX_SERVE_METRIC_RECORDING_METHOD: "PROCESS",
       },
     })`${command}`;
     this.hasMaxStarted = true;

--- a/src/api/max/maxServeService.ts
+++ b/src/api/max/maxServeService.ts
@@ -85,7 +85,7 @@ class MaxServeService {
       all: true,
       env: {
         MAX_SERVE_LOGS_OTLP_LEVEL: "DEBUG",
-        MAX_SERVE_DEPLOYMENT_ID: `INTERNAL_${modelName}`
+        MAX_SERVE_DEPLOYMENT_ID: `INTERNAL_MODULAR_CONSOLE`
       },
     })`${command}`;
     this.hasMaxStarted = true;

--- a/src/api/max/maxServeService.ts
+++ b/src/api/max/maxServeService.ts
@@ -85,9 +85,10 @@ class MaxServeService {
       all: true,
       env: {
         MAX_SERVE_LOGS_OTLP_LEVEL: "DEBUG",
-        MAX_SERVE_DEPLOYMENT_ID: `INTERNAL_MODULAR_CONSOLE`,
+        MAX_SERVE_DEPLOYMENT_ID: `INTERNAL_MODULAR_CONSOLE_${modelName}`,
         MAX_SERVE_METRIC_LEVEL: "DETAILED",
         MAX_SERVE_METRIC_RECORDING_METHOD: "PROCESS",
+        MODULAR_USER_ID: `INTERNAL_MODULAR_CONSOLE`,
       },
     })`${command}`;
     this.hasMaxStarted = true;

--- a/src/api/max/maxServeService.ts
+++ b/src/api/max/maxServeService.ts
@@ -83,6 +83,10 @@ class MaxServeService {
       cleanup: false,
       forceKillAfterDelay: false,
       all: true,
+      env: {
+        MAX_SERVE_LOGS_OTLP_LEVEL: "DEBUG",
+        MAX_SERVE_DEPLOYMENT_ID: `INTERNAL_${modelName}`
+      },
     })`${command}`;
     this.hasMaxStarted = true;
     this.monitorProcess();


### PR DESCRIPTION
Sets env vars to emit otel metrics for MAX Serve, this acts as
a staging ground for us to test our telemetry.
